### PR TITLE
Fixed compatibility with LuaJIT 2.1

### DIFF
--- a/src/lxplib.c
+++ b/src/lxplib.c
@@ -23,7 +23,7 @@
 #define luaL_Reg luaL_reg
 #endif
 
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM==501
+#if !defined(luaL_newlibtable) && (!defined LUA_VERSION_NUM || LUA_VERSION_NUM==501)
 /* Lua 5.0 or Lua 5.1 */
 /*
 ** Adapted from Lua 5.2.0


### PR DESCRIPTION
Hi,

We're using the latest version of `luaexpat` (1.3.2-1) downloaded from LuaRocks for a couple of plugins that we are developing for Kong 1.0rc2.  We have discovered that Kong 1.0rc2 is bundled with LuaJIT 2.1, which includes source files that luaexpat cannot be compiled against.

I've found [this commit](https://github.com/silverwind/luaexpat/commit/3a738c95eb966531e58fe24c0673e760ee99a426) which works around the problem.  I have tested this in our development environment informally and it seems to build (I haven't done extensive testing on this).  I hope you find this PR useful.

Thanks,

Leon